### PR TITLE
Added codesniffer, removed memory cap, updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ to develop is about 5 minutes.
 Requirements
 ------------
 This installation should work for all major flavors of linux, and 
-OSX. It has not been tested on windows, however should be supported.
+OSX. On Windows, Vagrant >= 1.8.2 is required. 
 
- * Vagrant  >1.8.0 [Install](https://docs.vagrantup.com/v2/installation/index.html)
+ * Vagrant  >1.8.2 [Install](https://docs.vagrantup.com/v2/installation/index.html)
  * Virtualbox [Download and install](https://www.virtualbox.org/wiki/Downloads)
  * Ansible [Install](https://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine)
  

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,8 +52,9 @@ Vagrant.configure(2) do |config|
   #
   config.vm.provider "virtualbox" do |vb|
 
-     # Customize the amount of memory on the VM:
-     vb.memory = "1024"
+     # Leave the RAM as default, and allow the user to customize it via VirtualBox
+     # Specifying it here forces this value on guest boot
+     #vb.memory = "1024"
   end
 
   # Enable provisioning with a shell script. Additional provisioners such as

--- a/provisioning/roles/drupal/tasks/main.yml
+++ b/provisioning/roles/drupal/tasks/main.yml
@@ -1,4 +1,0 @@
----
-
-- name: Install drush
-  apt: name=drush state=latest

--- a/provisioning/roles/drupal_coder/tasks/main.yml
+++ b/provisioning/roles/drupal_coder/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: install codesniffer
+  command: /usr/bin/pear install PHP_CodeSniffer-1.5.6
+  args:
+    creates: /usr/share/php/PHP/CodeSniffer.php
+
+- name: install codesniffer in drush
+  command: /usr/bin/drush -y pm-download coder-7.x-2.x-dev --destination=/home/vagrant/.drush
+  args:
+    creates: /home/vagrant/.drush/coder
+
+- name: fix drush permissions
+  command: chown -R vagrant.vagrant /home/vagrant/.drush

--- a/provisioning/site.yml
+++ b/provisioning/site.yml
@@ -13,8 +13,8 @@
     - update
     - apache
     - php
-    - drush
     - pecl
     - mysql
-
+    - drush
+    - drupal_coder
 


### PR DESCRIPTION
On Windows this requires a currently un-released version of Vagrant (1.8.2). This is due to Vagrant issue [GH-6740](https://github.com/mitchellh/vagrant/pull/6741).
